### PR TITLE
Fix the worrydream.com 404 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ Join us on slack at [**#awesome-explorables**](https://awesome-explorables.com/)
 *[&#8593; top](#contents)*
 * [Explorable Explanations](http://explorableexplanations.com)
 * [worrydream.com](http://worrydream.com/ScientificCommunicationAsSequentialArt/) - Scientific Communication As Sequential Art
-* [worrydream.com](http://worrydream.com/ladderofabstraction/) - up and down the ladder of abstraction – a systemic approach to interactive visualization
-* [worrydream.com](http://worrydream.com/explorableexplanations/) - Bret Victor's essay which coined the term "explorable explanations"
+* [worrydream.com](http://worrydream.com/LadderOfAbstraction/) - up and down the ladder of abstraction – a systemic approach to interactive visualization
+* [worrydream.com](http://worrydream.com/ExplorableExplanations/) - Bret Victor's essay which coined the term "explorable explanations"
 * [Reinventing Explanation](http://michaelnielsen.org/reinventing_explanation/) – prototyping an accessible explanation of simpson's paradox
 * [blog.ncase.me](http://blog.ncase.me/explorable-explanations/) - design patterns for explorable explanations
 * [simblob.blogspot.de](http://simblob.blogspot.de/2016/12/five-year-mission.html) - amit patel of red blob games looks back on 5 years of creating interactive explanations


### PR DESCRIPTION
Fixs the worrydream.com 404 links, it seems the url for the article was changed to upper CamelCase